### PR TITLE
likhith/trah-4188/incorporate POA enhancement for wallet

### DIFF
--- a/packages/account/src/Components/file-uploader-container/file-uploader-container.tsx
+++ b/packages/account/src/Components/file-uploader-container/file-uploader-container.tsx
@@ -64,10 +64,11 @@ const FileUploaderContainer = ({
                                 autoComplete='off'
                                 list_items={document_list}
                                 type='text'
-                                value={field.value?.text}
+                                value={field.value}
+                                label={placeholder}
                                 placeholder={placeholder ?? localize('Select a document')}
                                 onItemSelection={(item: TListItem) => {
-                                    setFieldValue('document_type', item, true);
+                                    setFieldValue('document_type', item.text, true);
                                 }}
                                 required
                             />

--- a/packages/account/src/Components/file-uploader-container/file-uploader-container.tsx
+++ b/packages/account/src/Components/file-uploader-container/file-uploader-container.tsx
@@ -63,7 +63,7 @@ const FileUploaderContainer = ({
                                 list_items={document_list}
                                 type='text'
                                 value={field.value?.text}
-                                placeholder={localize('Select a document')}
+                                placeholder={localize('Type of document')}
                                 onItemSelection={(item: TListItem) => {
                                     setFieldValue('document_type', item, true);
                                 }}

--- a/packages/account/src/Sections/Verification/ProofOfAddress/poa-mobile-layout.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfAddress/poa-mobile-layout.tsx
@@ -69,7 +69,7 @@ const POAMobileLayout = observer(
                 !!errors.address_state &&
                 !!errors.address_postcode
             );
-        }, [values]);
+        }, [values, errors, step.id]);
 
         return (
             <div className='poa-mobile-layout'>

--- a/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.tsx
@@ -14,6 +14,7 @@ import POADesktopLayout from './poa-desktop-layout';
 import { TPOAFormState } from '../../../Types';
 import { useTranslations } from '@deriv-com/translations';
 import POAMobileLayout from './poa-mobile-layout';
+import { getSupportedProofOfAddressDocuments } from '../../../Constants/file-uploader';
 
 type TProofOfAddressForm = {
     className: string;
@@ -28,7 +29,7 @@ type TFormInitialValues = Record<
     'address_line_1' | 'address_line_2' | 'address_city' | 'address_state' | 'address_postcode',
     string
 > & {
-    document_type?: Record<'text' | 'value', string>;
+    document_type?: string;
 };
 
 const ProofOfAddressForm = observer(
@@ -136,7 +137,7 @@ const ProofOfAddressForm = observer(
                 }
             }
 
-            if (!values.document_type?.value) {
+            if (!values.document_type) {
                 errors.document_type = localize('Document type is required.');
             }
 
@@ -189,8 +190,12 @@ const ProofOfAddressForm = observer(
 
             // upload files
             try {
+                // This is required as AutoComplate displays only the selected value
+                const selected_doc_type = getSupportedProofOfAddressDocuments().find(
+                    doc => doc.text === values.document_type
+                );
                 const api_response = await upload(document_files, {
-                    document_type: values.document_type?.value as DocumentUploadRequest['document_type'],
+                    document_type: selected_doc_type?.value as DocumentUploadRequest['document_type'],
                 });
 
                 if (api_response?.warning) {
@@ -256,7 +261,7 @@ const ProofOfAddressForm = observer(
             address_city,
             address_state,
             address_postcode,
-            document_type: { text: '', value: '' },
+            document_type: '',
         };
 
         if (api_initial_load_error) return <LoadErrorMessage error_message={api_initial_load_error} />;

--- a/packages/api-v2/types.ts
+++ b/packages/api-v2/types.ts
@@ -246,6 +246,10 @@ type KycAuthStatus = {
          * Current POA status.
          */
         status?: 'none' | 'pending' | 'rejected' | 'verified' | 'expired';
+        /**
+         * Supported documents per document_type.
+         */
+        supported_documents?: string[];
     };
     /**
      * POI authentication status details.

--- a/packages/cfd/src/Components/__tests__/cfd-poa.spec.tsx
+++ b/packages/cfd/src/Components/__tests__/cfd-poa.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockStore } from '@deriv/stores';
 import CFDPOA from '../cfd-poa';
@@ -89,6 +89,7 @@ describe('<CFDPOA />', () => {
                 address_city: 'test address_city',
                 address_state: 'test address_state',
                 address_postcode: 'test address_postcode',
+                country_code: 'in',
             },
             fetchResidenceList: jest.fn(() => Promise.resolve('')),
             getChangeableFields: jest.fn(() => []),
@@ -112,7 +113,8 @@ describe('<CFDPOA />', () => {
 
         const uploader = screen.getByTestId('dt_file_upload_input');
         const file = new File(['test file'], 'test_file.png', { type: 'image/png' });
-
+        const dt_document_type = screen.getByRole('textbox', { name: /Type of document/ });
+        fireEvent.change(dt_document_type, { target: { value: 'utility_bill' } });
         await waitFor(() => {
             userEvent.upload(uploader, file);
         });

--- a/packages/wallets/src/features/accounts/modules/Poa/Poa.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/Poa.scss
@@ -14,6 +14,6 @@
     @include mobile-or-tablet-screen {
         width: 100%;
         height: 100%;
-        padding: 1.6rem;
+        padding: unset;
     }
 }

--- a/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
@@ -11,7 +11,6 @@ import { usePoa } from './hooks';
 import { getPoaValidationSchema } from './utils';
 import './Poa.scss';
 
-
 type TPoaProps = {
     onCompletion?: VoidFunction;
 };
@@ -49,8 +48,6 @@ const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
     };
 
     if (showLoader) return <Loader />;
-
-    // const handleClickNext = () => setStep({ id: 2, text: localize('Upload proof of address') });
 
     return (
         <Formik

--- a/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { Formik, FormikValues } from 'formik';
 import { useTranslations } from '@deriv-com/translations';
-import { InlineMessage, Loader, Text } from '@deriv-com/ui';
+import { InlineMessage, Loader, Text, useDevice } from '@deriv-com/ui';
 import { ModalStepWrapper } from '../../../../components';
 import { THooks } from '../../../../types';
 import { Footer } from '../components';
@@ -16,7 +16,9 @@ type TPoaProps = {
 
 const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
     const { localize } = useTranslations();
+    const { isDesktop } = useDevice();
     const {
+        countryCode,
         errorSettings,
         initialStatus,
         initialValues,
@@ -74,8 +76,20 @@ const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
                                     <Text>{localize(errorSettings.message)}</Text>
                                 </InlineMessage>
                             )}
-                            <AddressSection />
-                            <DocumentSubmission />
+                            {isDesktop ? (
+                                <Fragment>
+                                    <AddressSection />
+                                    <DocumentSubmission countryCode={countryCode as string} />
+                                </Fragment>
+                            ) : (
+                                <Fragment>
+                                    <Text size='xs'>
+                                        {localize(
+                                            'To start trading with your real account, please complete the following steps:'
+                                        )}
+                                    </Text>
+                                </Fragment>
+                            )}
                         </div>
                     </ModalStepWrapper>
                 );

--- a/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/Poa.tsx
@@ -1,14 +1,26 @@
-import React, { Fragment, useEffect, useState } from 'react';
-import { Formik, FormikValues } from 'formik';
+import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Formik, FormikProps, FormikValues } from 'formik';
 import { useTranslations } from '@deriv-com/translations';
 import { InlineMessage, Loader, Text, useDevice } from '@deriv-com/ui';
 import { ModalStepWrapper } from '../../../../components';
 import { THooks } from '../../../../types';
 import { Footer } from '../components';
+import POAMobile from './components/POAMobile/POAMobile';
 import { AddressSection, DocumentSubmission, PoaUploadErrorMessage } from './components';
 import { usePoa } from './hooks';
+import { TPoaValues } from './types';
 import { getPoaValidationSchema } from './utils';
 import './Poa.scss';
+
+type TMobileFooterProps = {
+    handleClick: VoidFunction;
+    isDisabled: boolean;
+    nextText?: string;
+};
+
+const MobileFooter = ({ handleClick, isDisabled, nextText }: TMobileFooterProps) => (
+    <Footer disableNext={isDisabled} nextText={nextText} onClickNext={handleClick} />
+);
 
 type TPoaProps = {
     onCompletion?: VoidFunction;
@@ -29,6 +41,28 @@ const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
     } = usePoa();
     const [errorDocumentUpload, setErrorDocumentUpload] = useState<THooks.DocumentUpload['error']>();
     const [showLoader, setShowLoader] = useState(true);
+    const [step, setStep] = useState<{ id: number; text: string }>({ id: 1, text: localize('Enter your address') });
+
+    const formikRef = useRef<FormikProps<TPoaValues>>(null);
+
+    const shouldAllowDocumentUpload = useMemo(() => {
+        if (!formikRef.current) return false;
+
+        const { errors, values } = formikRef.current;
+
+        if (step.id === 2) {
+            return false;
+        }
+        return (
+            !values.firstLine &&
+            !!errors.firstLine &&
+            !!errors.secondLine &&
+            !values.townCityLine &&
+            !!errors.townCityLine &&
+            !!errors.stateProvinceLine &&
+            !!errors.zipCodeLine
+        );
+    }, [formikRef, step.id]);
 
     useEffect(() => {
         if (isSubmissionSuccess && onCompletion) {
@@ -48,10 +82,13 @@ const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
 
     if (showLoader) return <Loader />;
 
+    const handelClickNext = () => setStep({ id: 2, text: localize('Upload proof of address') });
+
     return (
         <Formik
             initialStatus={initialStatus}
             initialValues={initialValues}
+            innerRef={formikRef}
             onSubmit={upload}
             validationSchema={getPoaValidationSchema(localize)}
         >
@@ -65,29 +102,46 @@ const Poa: React.FC<TPoaProps> = ({ onCompletion }) => {
                     return <PoaUploadErrorMessage errorCode={errorDocumentUpload.code} onRetry={onErrorRetry} />;
                 }
 
+                let buttonConfig: TMobileFooterProps;
+
+                if (step.id === 1) {
+                    buttonConfig = {
+                        handleClick: handelClickNext,
+                        isDisabled: shouldAllowDocumentUpload,
+                    };
+                } else {
+                    buttonConfig = {
+                        handleClick: handleSubmit,
+                        isDisabled: !isValid,
+                        nextText: localize('Submit'),
+                    };
+                }
+
                 return (
                     <ModalStepWrapper
-                        renderFooter={() => <Footer disableNext={!isValid} onClickNext={handleSubmit} />}
+                        renderFooter={() =>
+                            isDesktop ? (
+                                <Footer disableNext={!isValid} onClickNext={handleSubmit} />
+                            ) : (
+                                <MobileFooter {...buttonConfig} />
+                            )
+                        }
                         title={localize('Add a real MT5 account')}
                     >
                         <div className='wallets-poa'>
-                            {errorSettings?.message && (
-                                <InlineMessage variant='error'>
-                                    <Text>{localize(errorSettings.message)}</Text>
-                                </InlineMessage>
-                            )}
                             {isDesktop ? (
                                 <Fragment>
-                                    <AddressSection />
+                                    {errorSettings?.message && (
+                                        <InlineMessage variant='error'>
+                                            <Text>{localize(errorSettings.message)}</Text>
+                                        </InlineMessage>
+                                    )}
+                                    <AddressSection hasError={Boolean(errorSettings?.message)} />
                                     <DocumentSubmission countryCode={countryCode as string} />
                                 </Fragment>
                             ) : (
                                 <Fragment>
-                                    <Text size='xs'>
-                                        {localize(
-                                            'To start trading with your real account, please complete the following steps:'
-                                        )}
-                                    </Text>
+                                    <POAMobile countryCode={countryCode as string} step={step} />
                                 </Fragment>
                             )}
                         </div>

--- a/packages/wallets/src/features/accounts/modules/Poa/components/AddressSection/AddressSection.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/AddressSection/AddressSection.scss
@@ -45,6 +45,7 @@
         align-items: flex-start;
         gap: 0.8rem;
         margin-bottom: 1rem;
+        line-height: 14px;
 
         &-message {
             width: 80rem;

--- a/packages/wallets/src/features/accounts/modules/Poa/components/AddressSection/AddressSection.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/AddressSection/AddressSection.tsx
@@ -1,30 +1,35 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { Localize, useTranslations } from '@deriv-com/translations';
-import { InlineMessage, Text } from '@deriv-com/ui';
+import { InlineMessage, Text, useDevice } from '@deriv-com/ui';
 import { FormDropdown, FormField } from '../../../../../../components';
-import { TAddressDetails } from '../../types';
+import { TAddressDetails, TAddressSectionProps } from '../../types';
 import './AddressSection.scss';
 
-const AddressSection: React.FC = () => {
+const AddressSection: React.FC<TAddressSectionProps> = ({ hasError }) => {
     const { localize } = useTranslations();
     const { status } = useFormikContext<TAddressDetails>();
+    const { isDesktop } = useDevice();
 
     return (
         <div className='wallets-address-section'>
-            <div className='wallets-address-section__title'>
-                <Text weight='bold'>
-                    <Localize i18n_default_text='Address' />
-                </Text>
-                <div className='wallets-address-section__title__divider' />
-            </div>
-            <div className='wallets-address-section__inline'>
-                <InlineMessage variant='warning'>
-                    <div className='wallets-address-section__inline-message'>
-                        <Localize i18n_default_text='For faster verification, input the same address here as in your proof of address document (see section below)' />
-                    </div>
-                </InlineMessage>
-            </div>
+            {isDesktop && (
+                <div className='wallets-address-section__title'>
+                    <Text weight='bold'>
+                        <Localize i18n_default_text='Address' />
+                    </Text>
+                    <div className='wallets-address-section__title__divider' />
+                </div>
+            )}
+            {!hasError && (
+                <div className='wallets-address-section__inline'>
+                    <InlineMessage variant='warning'>
+                        <div className='wallets-address-section__inline-message'>
+                            <Localize i18n_default_text='Use the same address that appears on your proof of address (utility bill, bank statement, etc.).' />
+                        </div>
+                    </InlineMessage>
+                </div>
+            )}
             <div className='wallets-address-section__input'>
                 <FormField label={localize('First line of address*')} name='firstLine' />
                 <FormField label={localize('Second line of address (optional)')} name='secondLine' />

--- a/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.scss
@@ -115,4 +115,11 @@
             width: 100%;
         }
     }
+
+    &__type-selection {
+        display: flex;
+        flex-direction: column;
+        gap: 1.6rem;
+        align-self: stretch;
+    }
 }

--- a/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.scss
@@ -121,5 +121,9 @@
         flex-direction: column;
         gap: 1.6rem;
         align-self: stretch;
+
+        label {
+            text-transform: none !important;
+        }
     }
 }

--- a/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/DocumentSubmission/DocumentSubmission.tsx
@@ -1,27 +1,62 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useFormikContext } from 'formik';
-import { useIsEuRegion } from '@deriv/api-v2';
+import { useIsEuRegion, useKycAuthStatus } from '@deriv/api-v2';
 import { LabelPairedArrowUpFromBracketXlFillIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Text, useDevice } from '@deriv-com/ui';
-import { Dropzone } from '../../../../../../components';
-import { TDocumentSubmission } from '../../types';
-import { getExampleImagesConfig } from '../../utils';
+import { Dropzone, FormDropdown } from '../../../../../../components';
+import { TDocumentSubmission, TDocumentSubmissionProps, TListItem } from '../../types';
+import { getExampleImagesConfig, getSupportedProofOfAddressDocuments } from '../../utils';
 import { CommonMistakesExamples } from '../CommonMistakesExamples';
 import './DocumentSubmission.scss';
 
-const DocumentSubmission: React.FC = () => {
+const DocumentSubmission: React.FC<TDocumentSubmissionProps> = ({ countryCode }) => {
     const { localize } = useTranslations();
     const { isDesktop } = useDevice();
     const { data: isEuRegion } = useIsEuRegion();
+    const { isLoading, kyc_auth_status: kycAuthStatus } = useKycAuthStatus({ country: countryCode });
+    const [documentList, setDocumentList] = useState<Required<TListItem>[]>([]);
     const { setFieldValue, values } = useFormikContext<TDocumentSubmission>();
 
+    useEffect(() => {
+        if (!isLoading && kycAuthStatus) {
+            const { address } = kycAuthStatus;
+            const { supported_documents: supportedDocuments } = address;
+            const docList = getSupportedProofOfAddressDocuments().filter(doc =>
+                supportedDocuments?.includes(doc.value)
+            );
+            setDocumentList(docList);
+        }
+    }, [isLoading, kycAuthStatus]);
+
     const listItems = [
-        localize('Utility bill: electricity, water, gas, or landline phone bill.'),
-        localize(
-            'Financial, legal, or government document: recent bank statement, affidavit, or government-issued letter.'
-        ),
-        localize('Home rental agreement: valid and current agreement.'),
+        {
+            id: 'utility_bill',
+            value: (
+                <Localize
+                    components={[<strong key={0} />]}
+                    i18n_default_text='<0>Utility bill:</0> Electricity, water, gas, or landline phone bill.'
+                />
+            ),
+        },
+        {
+            id: 'financial_legal_government_document',
+            value: (
+                <Localize
+                    components={[<strong key={0} />]}
+                    i18n_default_text='<0>Financial, legal, or government document:</0> Recent bank statement, affidavit, or government-issued letter.'
+                />
+            ),
+        },
+        {
+            id: 'tenancy_agreement',
+            value: (
+                <Localize
+                    components={[<strong key={0} />]}
+                    i18n_default_text='<0>Tenancy agreement:</0> Valid and current agreement.'
+                />
+            ),
+        },
     ];
 
     useEffect(() => {
@@ -34,7 +69,7 @@ const DocumentSubmission: React.FC = () => {
         <div className='wallets-poa__document'>
             <div className='wallets-poa__document__title'>
                 <Text weight='bold'>
-                    <Localize i18n_default_text='Document submission' />
+                    <Localize i18n_default_text='Submit your document' />
                 </Text>
                 <div className='wallets-poa__document__title__divider' />
             </div>
@@ -42,15 +77,15 @@ const DocumentSubmission: React.FC = () => {
                 <div className='wallets-poa__document__container__disclaimer'>
                     <Text size='sm' weight='bold'>
                         {localize(
-                            'We accept only these types of documents as proof of address. The document must be recent (issued within last {{timePeriod}} months) and include your name and address:',
+                            'We accept only the following documents as proof of address. The document must be issued within last {{timePeriod}} months and include your name and address:',
                             { timePeriod: isEuRegion ? '6' : '12' }
                         )}
                     </Text>
 
                     <ul className='wallets-poa__document__container__disclaimer__list'>
                         {listItems.map(item => (
-                            <li key={`list-item-${item}`}>
-                                <Text size='sm'>{item}</Text>
+                            <li key={`list-item-${item.id}`}>
+                                <Text size='sm'>{item.value}</Text>
                             </li>
                         ))}
                     </ul>
@@ -70,6 +105,20 @@ const DocumentSubmission: React.FC = () => {
                         ))}
                     </div>
                 </div>
+
+                <div className='wallets-poa__document__type-selection'>
+                    <Text size='sm' weight='bold'>
+                        <Localize i18n_default_text='Select the type of document:' />
+                    </Text>
+                    <FormDropdown
+                        isFullWidth
+                        label={localize('Type of document')}
+                        list={documentList}
+                        listHeight='sm'
+                        name='documentType'
+                    />
+                </div>
+
                 <div className='wallets-poa__document__container__upload'>
                     <Text size='sm' weight='bold'>
                         <Localize i18n_default_text='Upload file' />

--- a/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.scss
@@ -1,0 +1,60 @@
+.wallets-poa-mobile-layout {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    &__header {
+        display: flex;
+        flex-direction: column;
+    }
+
+    &__container {
+        padding: 2.4rem 1.6rem;
+    }
+
+    &__error-banner {
+        margin-bottom: 1.6rem;
+    }
+}
+
+.wallets-progress-container {
+    height: 0.2rem;
+    width: 80%;
+    background-color: var(--general-hover);
+    border-radius: 96px;
+    overflow: hidden;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.wallets-timeline {
+    background-color: var(--general-section-1);
+    padding: 0.4rem 1.6rem;
+    align-items: center;
+    height: 5.2rem;
+    display: flex;
+    &__item {
+        display: flex;
+    }
+    font-size: 12px;
+    line-height: 18px;
+}
+
+.wallets-progress-bar {
+    width: 0;
+    height: 100%;
+    background-color: var(--brand-red-coral);
+    border-radius: 96px;
+
+    &--animate {
+        animation: progressAnimation 0.8s ease-in-out forwards;
+    }
+}
+
+@keyframes progressAnimation {
+    0% {
+        width: 0;
+    }
+    100% {
+        width: 100%;
+    }
+}

--- a/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.scss
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.scss
@@ -31,12 +31,12 @@
     padding: 0.4rem 1.6rem;
     align-items: center;
     height: 5.2rem;
+    column-gap: 1.6rem;
     display: flex;
+
     &__item {
         display: flex;
     }
-    font-size: 12px;
-    line-height: 18px;
 }
 
 .wallets-progress-bar {

--- a/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import classnames from 'classnames';
+import { Localize, useTranslations } from '@deriv-com/translations';
+import { InlineMessage, Text } from '@deriv-com/ui';
+import { usePoa } from '../../hooks';
+import { AddressSection } from '../AddressSection';
+import { DocumentSubmission } from '../DocumentSubmission';
+import './POAMobile.scss';
+
+const ProgressBar = ({ isActive }: { isActive: boolean }) => (
+    <div className='wallet-progress-container'>
+        <div className={classnames('wallet-progress-bar', { 'wallet-progress-bar--animate': isActive })} />
+    </div>
+);
+
+type POAMobileProps = {
+    countryCode: string;
+    step: { id: number; text: string };
+};
+
+const POAMobile: React.FC<POAMobileProps> = ({ countryCode, step }) => {
+    const { localize } = useTranslations();
+    const { errorSettings } = usePoa();
+
+    return (
+        <div className='wallets-poa-mobile-layout'>
+            <div className='wallets-poa-mobile-layout__header'>
+                <Text as='p' className='wallet-timeline' size='2xs'>
+                    <Localize
+                        components={[<strong key={0} />]}
+                        i18n_default_text='<0>Step {{step}}/2:&nbsp;</0> {{title}}'
+                        values={{ step: step.id, title: step.text }}
+                    />
+                </Text>
+                <div className='wallet-timeline__item'>
+                    <ProgressBar isActive={step.id <= 2} />
+                    <ProgressBar isActive={step.id === 2} />
+                </div>
+            </div>
+            <div className='wallets-poa-mobile-layout__container'>
+                {errorSettings?.message && (
+                    <InlineMessage className='wallets-poa-mobile-layout__error-banner' variant='error'>
+                        <Text>{localize(errorSettings.message)}</Text>
+                    </InlineMessage>
+                )}
+                {step.id === 1 && <AddressSection hasError={Boolean(errorSettings?.message)} />}
+                {step.id === 2 && <DocumentSubmission countryCode={countryCode as string} />}
+            </div>
+        </div>
+    );
+};
+
+export default POAMobile;

--- a/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/components/POAMobile/POAMobile.tsx
@@ -1,52 +1,117 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import classnames from 'classnames';
+import { useFormikContext } from 'formik';
+import { LabelPairedArrowLeftMdBoldIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { InlineMessage, Text } from '@deriv-com/ui';
+import { ModalStepWrapper } from '../../../../../../components';
+import { Footer } from '../../../components';
 import { usePoa } from '../../hooks';
+import { TPoaValues } from '../../types';
 import { AddressSection } from '../AddressSection';
 import { DocumentSubmission } from '../DocumentSubmission';
 import './POAMobile.scss';
 
-const ProgressBar = ({ isActive }: { isActive: boolean }) => (
-    <div className='wallet-progress-container'>
-        <div className={classnames('wallet-progress-bar', { 'wallet-progress-bar--animate': isActive })} />
+const ProgressBar = ({ isActive }: { isActive?: boolean }) => (
+    <div className='wallets-progress-container'>
+        <div className={classnames('wallets-progress-bar', { 'wallets-progress-bar--animate': isActive })} />
     </div>
 );
 
 type POAMobileProps = {
     countryCode: string;
-    step: { id: number; text: string };
+    onCompletion?: VoidFunction;
 };
 
-const POAMobile: React.FC<POAMobileProps> = ({ countryCode, step }) => {
+const POAMobile: React.FC<POAMobileProps> = ({ countryCode, onCompletion }) => {
     const { localize } = useTranslations();
     const { errorSettings } = usePoa();
+    const { errors, isValid, values } = useFormikContext<TPoaValues>();
+    const [shouldRenderDocumentUpload, setShouldRenderDocumentUpload] = useState(false);
+
+    const isNextBtnDisabled = useMemo(() => {
+        if (shouldRenderDocumentUpload) {
+            return false;
+        }
+        return (
+            !values.firstLine ||
+            !!errors.firstLine ||
+            !!errors.secondLine ||
+            !values.townCityLine ||
+            !!errors.townCityLine ||
+            !!errors.stateProvinceLine ||
+            !!errors.zipCodeLine
+        );
+    }, [values, errors, shouldRenderDocumentUpload]);
+
+    if (shouldRenderDocumentUpload) {
+        return (
+            <ModalStepWrapper
+                disableAnimation
+                renderFooter={() => (
+                    <Footer disableNext={!isValid} nextText={localize('Submit')} onClickNext={onCompletion} />
+                )}
+                title={localize('Add a real MT5 account')}
+            >
+                <div className='wallets-poa-mobile-layout'>
+                    <div className='wallets-poa-mobile-layout__header'>
+                        <div className='wallets-timeline'>
+                            <LabelPairedArrowLeftMdBoldIcon onClick={() => setShouldRenderDocumentUpload(false)} />
+                            <Text align='start' as='p' lineHeight='sm' size='sm'>
+                                <Localize
+                                    components={[<strong key={0} />]}
+                                    i18n_default_text='<0>Step 2/2:&nbsp;</0> Upload proof of address'
+                                />
+                            </Text>
+                        </div>
+                        <div className='wallets-timeline__item'>
+                            <ProgressBar isActive />
+                            <ProgressBar isActive />
+                        </div>
+                    </div>
+                    <div className='wallets-poa-mobile-layout__container'>
+                        {errorSettings?.message && (
+                            <InlineMessage className='wallets-poa-mobile-layout__error-banner' variant='error'>
+                                <Text align='start'>{localize(errorSettings.message)}</Text>
+                            </InlineMessage>
+                        )}
+                        <DocumentSubmission countryCode={countryCode as string} />
+                    </div>
+                </div>
+            </ModalStepWrapper>
+        );
+    }
 
     return (
-        <div className='wallets-poa-mobile-layout'>
-            <div className='wallets-poa-mobile-layout__header'>
-                <Text as='p' className='wallet-timeline' size='2xs'>
-                    <Localize
-                        components={[<strong key={0} />]}
-                        i18n_default_text='<0>Step {{step}}/2:&nbsp;</0> {{title}}'
-                        values={{ step: step.id, title: step.text }}
-                    />
-                </Text>
-                <div className='wallet-timeline__item'>
-                    <ProgressBar isActive={step.id <= 2} />
-                    <ProgressBar isActive={step.id === 2} />
+        <ModalStepWrapper
+            renderFooter={() => (
+                <Footer disableNext={isNextBtnDisabled} onClickNext={() => setShouldRenderDocumentUpload(true)} />
+            )}
+            title={localize('Add a real MT5 account')}
+        >
+            <div className='wallets-poa-mobile-layout'>
+                <div className='wallets-poa-mobile-layout__header'>
+                    <Text as='p' className='wallets-timeline' lineHeight='sm' size='sm'>
+                        <Localize
+                            components={[<strong key={0} />]}
+                            i18n_default_text='<0>Step 1/2:&nbsp;</0> Enter your address'
+                        />
+                    </Text>
+                    <div className='wallets-timeline__item'>
+                        <ProgressBar isActive />
+                        <ProgressBar />
+                    </div>
+                </div>
+                <div className='wallets-poa-mobile-layout__container'>
+                    {errorSettings?.message && (
+                        <InlineMessage className='wallets-poa-mobile-layout__error-banner' variant='error'>
+                            <Text>{localize(errorSettings.message)}</Text>
+                        </InlineMessage>
+                    )}
+                    <AddressSection hasError={Boolean(errorSettings?.message)} />
                 </div>
             </div>
-            <div className='wallets-poa-mobile-layout__container'>
-                {errorSettings?.message && (
-                    <InlineMessage className='wallets-poa-mobile-layout__error-banner' variant='error'>
-                        <Text>{localize(errorSettings.message)}</Text>
-                    </InlineMessage>
-                )}
-                {step.id === 1 && <AddressSection hasError={Boolean(errorSettings?.message)} />}
-                {step.id === 2 && <DocumentSubmission countryCode={countryCode as string} />}
-            </div>
-        </div>
+        </ModalStepWrapper>
     );
 };
 

--- a/packages/wallets/src/features/accounts/modules/Poa/hooks/usePoa.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/hooks/usePoa.ts
@@ -1,9 +1,7 @@
 import { useCallback, useState } from 'react';
 import { FormikValues } from 'formik';
 import { DocumentUploadStatus, useDocumentUpload, useSettings, useStatesList } from '@deriv/api-v2';
-import { TAddressDetails, TDocumentSubmission } from '../types';
-
-type TPoaValues = TAddressDetails & TDocumentSubmission;
+import { TPoaValues } from '../types';
 
 const usePoa = () => {
     const {

--- a/packages/wallets/src/features/accounts/modules/Poa/hooks/usePoa.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/hooks/usePoa.ts
@@ -71,7 +71,7 @@ const usePoa = () => {
                 // upload POA document using document_upload
                 await uploadDocument({
                     document_issuing_country: settings?.country_code ?? undefined,
-                    document_type: 'proofaddress',
+                    document_type: values.documentType,
                     file: values.poaFile,
                 });
 
@@ -94,6 +94,9 @@ const usePoa = () => {
     );
 
     return {
+        /** Country code of Client's residence */
+        countryCode: settings?.country_code,
+
         /** Error returned from API calls for address details update and POA document upload */
         errorSettings,
 

--- a/packages/wallets/src/features/accounts/modules/Poa/types/types.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/types/types.ts
@@ -8,6 +8,12 @@ export type TAddressDetails = {
     zipCodeLine: THooks.AccountSettings['address_postcode'];
 };
 
+export type TPoaValues = TAddressDetails & TDocumentSubmission;
+
+export type TAddressSectionProps = {
+    hasError?: boolean;
+};
+
 export type TDocumentSubmission = { documentType?: string; poaFile?: File };
 
 export type TDocumentSubmissionProps = {

--- a/packages/wallets/src/features/accounts/modules/Poa/types/types.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/types/types.ts
@@ -8,4 +8,14 @@ export type TAddressDetails = {
     zipCodeLine: THooks.AccountSettings['address_postcode'];
 };
 
-export type TDocumentSubmission = { poaFile?: File };
+export type TDocumentSubmission = { documentType?: string; poaFile?: File };
+
+export type TDocumentSubmissionProps = {
+    countryCode: string;
+};
+
+/** Type for the list of items in a dropdown or select */
+export type TListItem = {
+    text?: string;
+    value?: string;
+};

--- a/packages/wallets/src/features/accounts/modules/Poa/utils/constants.tsx
+++ b/packages/wallets/src/features/accounts/modules/Poa/utils/constants.tsx
@@ -7,6 +7,7 @@ import {
     DerivLightIcOldIssuedDocumentMoreThan12Icon,
 } from '@deriv/quill-icons';
 import { localize } from '@deriv-com/translations';
+import { TListItem } from '../types';
 
 type TExampleImageConfig = {
     description: React.ReactNode;
@@ -39,3 +40,32 @@ export const getExampleImagesConfig = (): TExampleImageConfig[] => [
         image: DerivLightIcEnvelopeIcon,
     },
 ];
+
+export const getSupportedProofOfAddressDocuments = (): Required<TListItem>[] => {
+    return [
+        {
+            text: localize('Utility bill (electricity, water, gas)'),
+            value: 'utility_bill',
+        },
+        {
+            text: localize('Landline phone bill'),
+            value: 'phone_bill',
+        },
+        {
+            text: localize('Bank statement'),
+            value: 'bank_statement',
+        },
+        {
+            text: localize('Official residence declaration or affidavit'),
+            value: 'affidavit',
+        },
+        {
+            text: localize('Official letter issued by the government or solicitor'),
+            value: 'official_letter',
+        },
+        {
+            text: localize('Rental/tenancy agreement'),
+            value: 'rental_agreement',
+        },
+    ];
+};

--- a/packages/wallets/src/features/accounts/modules/Poa/utils/poaValidationSchema.ts
+++ b/packages/wallets/src/features/accounts/modules/Poa/utils/poaValidationSchema.ts
@@ -4,6 +4,7 @@ import { fileValidator } from '../../ManualService/components/utils';
 
 export const getPoaValidationSchema = (localize: TTranslations['localize']) =>
     Yup.object().shape({
+        documentType: Yup.string().required(localize('Document type is required.')),
         firstLine: Yup.string()
             .trim()
             .required(localize('First line of address is required.'))


### PR DESCRIPTION
## Changes:

- Fetching supported documents for POA from `kyc_auth_status` API
- Populating Select the type of document field in POA section
- Configuring the document upload payload with the selected document type instead of hardcoding `proofaddress` as value
- Added missing types
